### PR TITLE
Fixes Celluloid warning

### DIFF
--- a/lib/sidetiq.rb
+++ b/lib/sidetiq.rb
@@ -7,7 +7,7 @@ require 'time'
 # gems
 require 'ice_cube'
 require 'sidekiq'
-require 'celluloid'
+require 'celluloid/current'
 
 # internal
 require 'sidetiq/config'


### PR DESCRIPTION
Requires celluloid/current to be loaded. This is due to the Celluloid project. Without that change it warns about: 'Celluloid x.x.x is running in BACKPORTED mode.'
